### PR TITLE
rp/adc: fix potential race condition

### DIFF
--- a/embassy-rp/src/adc.rs
+++ b/embassy-rp/src/adc.rs
@@ -205,11 +205,13 @@ impl<'d> Adc<'d, Async> {
 
     fn wait_for_ready() -> impl Future<Output = ()> {
         let r = Self::regs();
-        r.inte().write(|w| w.set_fifo(true));
-        compiler_fence(Ordering::SeqCst);
 
         poll_fn(move |cx| {
             WAKER.register(cx.waker());
+
+            r.inte().write(|w| w.set_fifo(true));
+            compiler_fence(Ordering::SeqCst);
+
             if r.cs().read().ready() {
                 return Poll::Ready(());
             }


### PR DESCRIPTION
This commit rearranges the Adc::wait_for_ready function to make sure that wakers are registered before the interrupt is enabled, and keeps enabling the interrupt until the ADC is ready